### PR TITLE
Rename SchoolLogos to ProminentLogos, switch to GatsbyImage

### DIFF
--- a/data/prominent_logo.yml
+++ b/data/prominent_logo.yml
@@ -1,0 +1,7 @@
+- name: City of London School for Boys
+  logoPath: logos/clsb-transparent.png
+  url: https://cityoflondonschool.org.uk
+
+- name: City of London School for Girls
+  logoPath: logos/clsg-transparent.png
+  url: https://clsg.org.uk

--- a/data/prominent_logo.yml
+++ b/data/prominent_logo.yml
@@ -1,7 +1,7 @@
-- name: City of London School for Boys
-  logoPath: logos/clsb-transparent.png
-  url: https://cityoflondonschool.org.uk
-
 - name: City of London School for Girls
   logoPath: logos/clsg-transparent.png
   url: https://clsg.org.uk
+
+- name: City of London School for Boys
+  logoPath: logos/clsb-transparent.png
+  url: https://cityoflondonschool.org.uk

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -51,6 +51,16 @@ const config: GatsbyConfig = {
 				prepareUrl: (url: string) => `${config.siteMetadata!.assetBasePath}${url}`,
 			},
 		},
+		{
+			resolve: "gatsby-plugin-remote-images",
+			options: {
+				nodeType: "ProminentLogoYaml",
+				imagePath: "logoPath",
+				name: "dynamicImage",
+				// siteMetdata could be undefined, but is not in our use case, so use ! (definitely assigned)
+				prepareUrl: (url: string) => `${config.siteMetadata!.assetBasePath}${url}`,
+			},
+		},
 		`gatsby-plugin-image`,
 		`gatsby-plugin-sharp`,
 		`gatsby-transformer-sharp`, // Needed for dynamic images

--- a/src/components/footer/components/prominentLogos.tsx
+++ b/src/components/footer/components/prominentLogos.tsx
@@ -29,9 +29,7 @@ const ProminentLogos = ({ nodes, assetPath, size, containerSx }: ProminentLogoPr
 							/>
 						</a>
 					</Grid>
-				)
-
-
+				);
 			})}
 		</Grid>
 	);

--- a/src/components/footer/components/prominentLogos.tsx
+++ b/src/components/footer/components/prominentLogos.tsx
@@ -4,14 +4,14 @@ import { Grid } from "@mui/material";
 import { ProminentLogoNode } from "../../../types/graphql/prominentLogoNode";
 import { GatsbyImage, ImageDataLike, getImage } from "gatsby-plugin-image";
 
-type SchoolLogoProps = {
+type ProminentLogoProps = {
 	nodes: ProminentLogoNode[];
 	assetPath: string;
 	size: number;
 	containerSx: object;
 };
 
-const SchoolLogos = ({ nodes, assetPath, size, containerSx }: SchoolLogoProps) => {
+const ProminentLogos = ({ nodes, assetPath, size, containerSx }: ProminentLogoProps) => {
 	return (
 		<Grid item container spacing={0} sx={containerSx}>
 			{nodes.map(node => {
@@ -37,4 +37,4 @@ const SchoolLogos = ({ nodes, assetPath, size, containerSx }: SchoolLogoProps) =
 	);
 };
 
-export default SchoolLogos;
+export default ProminentLogos;

--- a/src/components/footer/components/schoolLogos.tsx
+++ b/src/components/footer/components/schoolLogos.tsx
@@ -1,34 +1,38 @@
 import * as React from "react";
 
 import { Grid } from "@mui/material";
+import { ProminentLogoNode } from "../../../types/graphql/prominentLogoNode";
+import { GatsbyImage, ImageDataLike, getImage } from "gatsby-plugin-image";
 
 type SchoolLogoProps = {
+	nodes: ProminentLogoNode[];
 	assetPath: string;
 	size: number;
 	containerSx: object;
 };
 
-const SchoolLogos = ({ assetPath, size, containerSx }: SchoolLogoProps) => {
+const SchoolLogos = ({ nodes, assetPath, size, containerSx }: SchoolLogoProps) => {
 	return (
 		<Grid item container spacing={0} sx={containerSx}>
-			<Grid item xs={size}>
-				<a href="https://clsg.org.uk/" target="_blank">
-					<img
-						style={{ maxWidth: "100%", maxHeight: "100%" }}
-						src={assetPath + "logos/clsg-transparent.png"}
-						alt="City of London School for Girls Logo"
-					/>
-				</a>
-			</Grid>
-			<Grid item xs={size}>
-				<a href="https://www.cityoflondonschool.org.uk/" target="_blank">
-					<img
-						style={{ maxWidth: "100%", maxHeight: "100%" }}
-						src={assetPath + "logos/clsb-transparent.png"}
-						alt="City of London School for Boys Logo"
-					/>
-				</a>
-			</Grid>
+			{nodes.map(node => {
+				// To make TS happy, use the notNull assertion for dynamicImage as well as getImage's return value.
+				// Also cast dynamicImage to ImageDataLike (mismatched so must cast to unknown first.)
+				const image = getImage(node.dynamicImage! as unknown as ImageDataLike)!;
+
+				return (
+					<Grid item xs={size}>
+						<a href={node.url!} target="_blank">
+							<GatsbyImage
+								image={image}
+								style={{ maxWidth: "100%", maxHeight: "100%" }}
+								alt={`${node.name} Logo`}
+							/>
+						</a>
+					</Grid>
+				)
+
+
+			})}
 		</Grid>
 	);
 };

--- a/src/components/footer/desktop.tsx
+++ b/src/components/footer/desktop.tsx
@@ -33,6 +33,7 @@ const DesktopFooter = ({ data }) => {
 							containerSx={{ justifyContent: "flex-end" }}
 							size={3}
 							assetPath={assetPath}
+							nodes={data.allProminentLogoYaml.nodes}
 						/>
 
 						{/** Bottom Right: Sponsor Logos */}

--- a/src/components/footer/desktop.tsx
+++ b/src/components/footer/desktop.tsx
@@ -2,7 +2,7 @@ import { Grid, Paper } from "@mui/material";
 
 import * as React from "react";
 
-import SchoolLogos from "./components/schoolLogos";
+import ProminentLogos from "./components/prominentLogos";
 import SponsorLogos from "./components/sponsorLogos";
 import SourceAndSha from "./components/sourceAndSha";
 import Copyright from "./components/copyright";
@@ -29,7 +29,7 @@ const DesktopFooter = ({ data }) => {
 					{/** Right side */}
 					<Grid container xs={6}>
 						{/** Top Right: School Logos */}
-						<SchoolLogos
+						<ProminentLogos
 							containerSx={{ justifyContent: "flex-end" }}
 							size={3}
 							assetPath={assetPath}

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -34,6 +34,29 @@ export const query = graphql`
 		}
 	}
 
+	fragment FooterProminentLogoYamlFragment on ProminentLogoYamlConnection {
+		nodes {
+			name
+			url
+			# static, higher res (original) image
+			#logoPath
+			# gatsby-plugin-image (using logoPath)
+			dynamicImage {
+				childImageSharp {
+					gatsbyImageData(
+						# Set by height, width props.
+						#layout: FIXED
+						width: 376
+						# No placeholder image (team page has blurred placeholders)
+						placeholder: NONE
+						# WebP only.
+						formats: [WEBP]
+					)
+				}
+			}
+		}
+	}
+
 	fragment FooterSiteFragment on Site {
 		siteMetadata {
 			sha

--- a/src/components/footer/mobile.tsx
+++ b/src/components/footer/mobile.tsx
@@ -20,7 +20,12 @@ const MobileFooter = ({ data }) => {
 					{/** Desktop: Top left (nothing yet) */}
 
 					{/** School Logos */}
-					<ProminentLogos containerSx={{}} size={6} assetPath={assetPath} nodes={data.allProminentLogoYaml.nodes} />
+					<ProminentLogos
+						containerSx={{}}
+						size={6}
+						assetPath={assetPath}
+						nodes={data.allProminentLogoYaml.nodes}
+					/>
 
 					{/** Sponsors */}
 					<SponsorLogos

--- a/src/components/footer/mobile.tsx
+++ b/src/components/footer/mobile.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Grid, Paper } from "@mui/material";
 
 import SponsorLogos from "./components/sponsorLogos";
-import SchoolLogos from "./components/schoolLogos";
+import ProminentLogos from "./components/prominentLogos";
 import SourceAndSha from "./components/sourceAndSha";
 import Copyright from "./components/copyright";
 
@@ -20,7 +20,7 @@ const MobileFooter = ({ data }) => {
 					{/** Desktop: Top left (nothing yet) */}
 
 					{/** School Logos */}
-					<SchoolLogos containerSx={{}} size={6} assetPath={assetPath} nodes={data.allProminentLogoYaml.nodes} />
+					<ProminentLogos containerSx={{}} size={6} assetPath={assetPath} nodes={data.allProminentLogoYaml.nodes} />
 
 					{/** Sponsors */}
 					<SponsorLogos

--- a/src/components/footer/mobile.tsx
+++ b/src/components/footer/mobile.tsx
@@ -20,7 +20,7 @@ const MobileFooter = ({ data }) => {
 					{/** Desktop: Top left (nothing yet) */}
 
 					{/** School Logos */}
-					<SchoolLogos containerSx={{}} size={6} assetPath={assetPath} />
+					<SchoolLogos containerSx={{}} size={6} assetPath={assetPath} nodes={data.allProminentLogoYaml.nodes} />
 
 					{/** Sponsors */}
 					<SponsorLogos

--- a/src/components/mdxPageTemplate.tsx
+++ b/src/components/mdxPageTemplate.tsx
@@ -13,6 +13,9 @@ export const query = graphql`
 		allSponsorYaml {
 			...FooterSponsorYamlFragment
 		}
+		allProminentLogoYaml {
+			...FooterProminentLogoYamlFragment
+		}
 	}
 `;
 

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -319,5 +319,8 @@ export const query = graphql`
 		allSponsorYaml {
 			...FooterSponsorYamlFragment
 		}
+		allProminentLogoYaml {
+			...FooterProminentLogoYamlFragment
+		}
 	}
 `;

--- a/src/types/graphql/prominentLogoNode.ts
+++ b/src/types/graphql/prominentLogoNode.ts
@@ -1,0 +1,6 @@
+import { NodeUnneededKeys } from "./nodeUnneededKeys";
+
+/**
+ * {@link Queries.ProminentLogoYaml} without GraphQL specific keys
+ */
+export type ProminentLogoNode = Omit<Queries.ProminentLogoYaml, keyof NodeUnneededKeys>;


### PR DESCRIPTION
Fixes logos loading at max size before a layout change to the correct size during a fresh page load.